### PR TITLE
Add initial classes RecordSet, RecordScalar and Record

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ python:
 
 # Install the codecov pip dependency
 install:
-  - pip install codecov pytest
+  - pip install codecov pytest psycopg2
   - pip install -r requirements.txt
 
 # Run the unit test

--- a/README.md
+++ b/README.md
@@ -43,11 +43,25 @@ cm = ConnectionManager(".connections.yaml")
 sql = "SELECT name, age FROM people WHERE category = :category"
 params = {"category": 5}
 result = cm.recordset(con_name="my-database", sql=sql, params=params)
+
+# result.headings == ["name", "age"]
+
+# result.data == [
+#    ("Jim", 30),
+#    ("Bones", 35)
+# ]
+
+# result.as_dict == [
+#    {"name": "Jim", "age": 30},
+#    {"name": "Bones", "age": 35}
+# ]
+
+# result.column["name"] == ["Jim", "Bones"]
 ```
 
-The `recordset()` method returns a tuple of (Data, Headings). "Data" is a list of row tuples.
-Headings is a list of field names from the query.
-
+The `recordset()` method returns a RecordSet object with a bunch of handy methods for getting at the data.
+There is also a `cm.record()` method for queries you know only return a single record, and
+a `cm.record_scalar()` method for queries where you're after a single datum. 
 
 ### In Development
 
@@ -129,6 +143,11 @@ test-connections:
     default: true
 ```
 
+## Chat
+
+Say hello in the Gary: https://gitter.im/SimQLe/community
+
+
 ## Author
 
 [Tom Malkin](https://github.com/Harlekuin)
@@ -153,3 +172,5 @@ test-connections:
   - Default parameter added
 - 0.4.0
   - Development added as a connection mode
+- 0.5.0
+  - RecordSet, Record and RecordScalar objects added

--- a/features/connection-mode.feature
+++ b/features/connection-mode.feature
@@ -19,7 +19,7 @@ Feature: connection mode changing
 		Then simqle test environment variable changes connection type
 
 
-#	# for backwards compatibility, SIMQLE_TEST should autoamatically set SimQLe to test mode
+#	# for backwards compatibility, SIMQLE_TEST should automatically set SimQLe to test mode
 #	@fixture.connections.file
 #	@fixture.sqlite
 	Scenario: Wrong Simqle Mode throws an exception

--- a/features/connection-mode.feature
+++ b/features/connection-mode.feature
@@ -1,28 +1,25 @@
 Feature: connection mode changing
 
-	As a SimQLe user
-	I want to be able to change SimQLe to be in various modes
-	So I can write integration tests that look at test databases
+  As a SimQLe user
+  I want to be able to change SimQLe to be in various modes
+  So I can write integration tests that look at test databases
 
-	@fixture.connections.file
-	@fixture.sqlite
-	Scenario: Changing Connection Mode
-		Given we have a testmode .connections.yaml file in root
-		Then simqle mode environment variable changes connection type
+  @fixture.connections.file
+  @fixture.sqlite
+  Scenario: Changing Connection Mode
+    Given we have a testmode .connections.yaml file in root
+    Then simqle mode environment variable changes connection type
 
 
 	# for backwards compatibility, SIMQLE_TEST should autoamatically set SimQLe to test mode
-	@fixture.connections.file
-	@fixture.sqlite
-	Scenario: Setting Test Mode
-		Given we have a testmode .connections.yaml file in root
-		Then simqle test environment variable changes connection type
+  @fixture.connections.file
+  @fixture.sqlite
+  Scenario: Setting Test Mode
+    Given we have a testmode .connections.yaml file in root
+    Then simqle test environment variable changes connection type
 
 
-#	# for backwards compatibility, SIMQLE_TEST should automatically set SimQLe to test mode
-#	@fixture.connections.file
-#	@fixture.sqlite
-	Scenario: Wrong Simqle Mode throws an exception
-		Given we have a testmode .connections.yaml file in root
-		When we load an unknown connection mode
-		Then it throws a UnknownSimqleMode with message "wrongmode is an unknown simqle mode"
+  Scenario: Wrong Simqle Mode throws an exception
+    Given we have a testmode .connections.yaml file in root
+    When we load an unknown connection mode
+    Then it throws a UnknownSimqleMode with message "wrongmode is an unknown simqle mode"

--- a/features/defined-connections.feature
+++ b/features/defined-connections.feature
@@ -2,27 +2,27 @@ Feature: database connections
 
 	As a SimQLe user
 	I want to be able to connect to various databases
-	So I can execute queries and return recordsets on it
+	So I can execute queries And return recordsets on it
 
 # --- A basic test of each of the supported databases ---
 
 	@fixture.sqlite
 	Scenario: sqlite test
 		When we load the test connections file
-		AND we create a table on sqlite
-		AND we insert an entry on sqlite
+		And we create a table on sqlite
+		And we insert an entry on sqlite
 		Then the entry exists in the table on sqlite
 
 	Scenario: mysql test
 		When we load the test connections file
-		AND we create a table on mysql
-		AND we insert an entry on mysql
+		And we create a table on mysql
+		And we insert an entry on mysql
 		Then the entry exists in the table on mysql
 
 	Scenario: postgresql test
 		When we load the test connections file
-		AND we create a table on postgresql
-		AND we insert an entry on postgresql
+		And we create a table on postgresql
+		And we insert an entry on postgresql
 		Then the entry exists in the table on postgresql
 
 
@@ -46,18 +46,18 @@ Feature: database connections
 		Then the connection has been properly escaped
 
 
-# --- Error handling ---
+# --- Error hAndling ---
 
 	@fixture.sqlite
 	Scenario: An error occurs when an unknown connection name is given
 		When we load the test connections file
-		AND we create a table on wrongname
+		And we create a table on wrongname
 		Then it throws a UnknownConnectionError with message "Unknown connection my-wrongname-database"
 
 	@fixture.sqlite
 	Scenario: A SQL error raises an exception
 		When we load the test connections file
-		AND we execute sql with an error on sqlite
+		And we execute sql with an error on sqlite
 		Then it throws a Exception
 
 
@@ -66,8 +66,8 @@ Feature: database connections
 	@fixture.sqlite
 	Scenario: No connection name loads a default connection
 		When we load the test connections file with a default connection
-		AND we create a table with no connection name
-		AND we insert an entry with no connection name
+		And we create a table with no connection name
+		And we insert an entry with no connection name
 		Then the entry exists in the default table
 
 	@fixture.sqlite
@@ -78,7 +78,7 @@ Feature: database connections
 	@fixture.sqlite
 	Scenario: No connection name given but no default connection throws an error
 		When we load the test connections file
-		AND we create a table with no connection name
+		And we create a table with no connection name
 		Then it throws a NoDefaultConnectionError with message "No Connection name was specified but no default connection exists."
 
 	@fixture.sqlite

--- a/features/defined-connections.feature
+++ b/features/defined-connections.feature
@@ -1,87 +1,106 @@
 Feature: database connections
 
-	As a SimQLe user
-	I want to be able to connect to various databases
-	So I can execute queries And return recordsets on it
+  As a SimQLe user
+  I want to be able to connect to various databases
+  So I can execute queries And return recordsets on it
 
 # --- A basic test of each of the supported databases ---
 
-	@fixture.sqlite
-	Scenario: sqlite test
-		When we load the test connections file
-		And we create a table on sqlite
-		And we insert an entry on sqlite
-		Then the entry exists in the table on sqlite
+  @fixture.sqlite
+  Scenario: sqlite test
+    When we load the test connections file
+    And we create a table on sqlite
+    And we insert an entry on sqlite
+    Then the entry exists in the table on sqlite
 
-	Scenario: mysql test
-		When we load the test connections file
-		And we create a table on mysql
-		And we insert an entry on mysql
-		Then the entry exists in the table on mysql
+  Scenario: mysql test
+    When we load the test connections file
+    And we create a table on mysql
+    And we insert an entry on mysql
+    Then the entry exists in the table on mysql
 
-	Scenario: postgresql test
-		When we load the test connections file
-		And we create a table on postgresql
-		And we insert an entry on postgresql
-		Then the entry exists in the table on postgresql
+  Scenario: postgresql test
+    When we load the test connections file
+    And we create a table on postgresql
+    And we insert an entry on postgresql
+    Then the entry exists in the table on postgresql
+
+
+# --- Test the other return types on sqlite
+  @fixture.sqlite
+  Scenario: Data exists test
+    When we load the test connections file
+    And we create a table on sqlite
+    And we insert an entry on sqlite
+    Then we can return a Recordset
+    And we can return a Record
+    And we can return a RecordScalar
+
+  @fixture.sqlite
+  Scenario: Data doesn't exists test
+    When we load the test connections file
+    And we create a table on sqlite
+    Then we can return an empty Recordset
+    And we can return an empty Record
+    And we can return an empty RecordScalar
 
 
 # --- Testing other functionality ---
 
-	@fixture.sqlite
-	Scenario: get engine test
-		When we load the test connections file
-		Then we can get the connection object for sqlite
+  @fixture.sqlite
+  Scenario: get engine test
+    When we load the test connections file
+    Then we can get the connection object for sqlite
 
-	@fixture.sqlite
-	Scenario: reset connections test
-		When we load the test connections file
-		Then we can reset the connections
+  @fixture.sqlite
+  Scenario: reset connections test
+    When we load the test connections file
+    Then we can reset the connections
 
-	@fixture.connections.file
-	@fixture.sqlite
-	Scenario: A connection with url-escape is suitable
-		Given we have a .connections.yaml file in root
-		When we load a connection file from a default location
-		Then the connection has been properly escaped
-
-
-# --- Error hAndling ---
-
-	@fixture.sqlite
-	Scenario: An error occurs when an unknown connection name is given
-		When we load the test connections file
-		And we create a table on wrongname
-		Then it throws a UnknownConnectionError with message "Unknown connection my-wrongname-database"
-
-	@fixture.sqlite
-	Scenario: A SQL error raises an exception
-		When we load the test connections file
-		And we execute sql with an error on sqlite
-		Then it throws a Exception
+  @fixture.connections.file
+  @fixture.sqlite
+  Scenario: A connection with url-escape is suitable
+    Given we have a .connections.yaml file in root
+    When we load a connection file from a default location
+    Then the connection has been properly escaped
 
 
-	# --- Testing default connection functionality ---
+# --- Error Handling ---
 
-	@fixture.sqlite
-	Scenario: No connection name loads a default connection
-		When we load the test connections file with a default connection
-		And we create a table with no connection name
-		And we insert an entry with no connection name
-		Then the entry exists in the default table
+  @fixture.sqlite
+  Scenario: An error occurs when an unknown connection name is given
+    When we load the test connections file
+    And we create a table on wrongname
+    Then it throws a UnknownConnectionError with message "Unknown connection my-wrongname-database"
 
-	@fixture.sqlite
-	Scenario: Multiple default connections throws an error
-		When we load the test connections file with a 2 default connections
-		Then it throws a MultipleDefaultConnectionsError with message "More than 1 default connection was specified."
+  @fixture.sqlite
+  Scenario: A SQL error raises an exception
+    When we load the test connections file
+    And we execute sql with an error on sqlite
+    Then it throws a Exception
 
-	@fixture.sqlite
-	Scenario: No connection name given but no default connection throws an error
-		When we load the test connections file
-		And we create a table with no connection name
-		Then it throws a NoDefaultConnectionError with message "No Connection name was specified but no default connection exists."
 
-	@fixture.sqlite
-	Scenario: If the test default connection doesn't match the production default connection it throws an error
-		When we load the test connections file with wrong default connections
-		Then it throws a EnvironSyncError with message "The default connection in connections doesn't match the default connection in the test connections."
+# --- Testing default connection functionality ---
+
+  @fixture.sqlite
+  Scenario: No connection name loads a default connection
+    When we load the test connections file with a default connection
+    And we create a table with no connection name
+    And we insert an entry with no connection name
+    Then the entry exists in the default table
+
+  @fixture.sqlite
+  Scenario: Multiple default connections throws an error
+    When we load the test connections file with a 2 default connections
+    Then it throws a MultipleDefaultConnectionsError with message "More than 1 default connection was specified."
+
+  @fixture.sqlite
+  Scenario: No connection name given but no default connection throws an error
+    When we load the test connections file
+    And we create a table with no connection name
+    Then it throws a NoDefaultConnectionError with message "No Connection name was specified but no default connection exists."
+
+  @fixture.sqlite
+  Scenario: If the test default connection doesn't match the production default connection it throws an error
+    When we load the test connections file with wrong default connections
+    Then it throws a EnvironSyncError with message "The default connection in connections doesn't match the default connection in the test connections."

--- a/features/internal-connection-manager.feature
+++ b/features/internal-connection-manager.feature
@@ -1,30 +1,30 @@
 Feature: database connections
 
-	As a SimQLe user
-	I want to be able to use the internal connection manager
-	So each module can utilise the same connections
+  As a SimQLe user
+  I want to be able to use the internal connection manager
+  So each module can utilise the same connections
 
-	@fixture.connections.file
-	@fixture.sqlite
-	Scenario: Internal Manager test
-		Given we have a .connections.yaml file in root
-		When we internally load connections
-		Then the internal connection is loaded
-
-
-	@fixture.connections.file
-	@fixture.sqlite
-	Scenario: Internal Manager reset connections
-		Given we have a .connections.yaml file in root
-		When we internally load connections
-		Then we can internally reset the connections
+  @fixture.connections.file
+  @fixture.sqlite
+  Scenario: Internal Manager test
+    Given we have a .connections.yaml file in root
+    When we internally load connections
+    Then the internal connection is loaded
 
 
-	@fixture.connections.file
-	@fixture.sqlite
-	Scenario: Internal Manager test
-		Given we have a .connections.yaml file in root
-		When we internally load connections
-		AND we create an internal table on sqlite
-		AND we insert an internal entry on sqlite
-		THEN the entry exists in the internal table on sqlite
+  @fixture.connections.file
+  @fixture.sqlite
+  Scenario: Internal Manager reset connections
+    Given we have a .connections.yaml file in root
+    When we internally load connections
+    Then we can internally reset the connections
+
+
+  @fixture.connections.file
+  @fixture.sqlite
+  Scenario: Internal Manager test
+    Given we have a .connections.yaml file in root
+    When we internally load connections
+    And we create an internal table on sqlite
+    And we insert an internal entry on sqlite
+    Then the entry exists in the internal table on sqlite

--- a/features/steps/general.py
+++ b/features/steps/general.py
@@ -7,7 +7,7 @@ from simqle import (
 )
 from simqle import internal
 from simqle.exceptions import *
-from .constants import (
+from constants import (
     CONNECTIONS_FILE,
     CREATE_TABLE_SYNTAX,
     TEST_TABLE_NAME,
@@ -35,14 +35,14 @@ def add_connections_file_to_root(context):
     # define our test file
     connections_file = {
         "connections": [
-                {"name": "my-sqlite-database",
-                 "driver": "sqlite:///",
-                 "connection": "/tmp/database.db", },
-                {"name": "my-sqlite-database-escaped",
-                 "driver": "sqlite:///",
-                 "connection": "A connection with spaces",
-                 "url_escape": True, },
-                ]}
+            {"name": "my-sqlite-database",
+             "driver": "sqlite:///",
+             "connection": "/tmp/database.db", },
+            {"name": "my-sqlite-database-escaped",
+             "driver": "sqlite:///",
+             "connection": "A connection with spaces",
+             "url_escape": True, },
+        ]}
 
     # write to our test file in a default location
     with open("./.connections.yaml", "w") as outfile:
@@ -56,6 +56,7 @@ def remove_default_connections_files(context):
         os.remove("./.connections.yaml")
     except OSError:
         pass
+
 
 # --- Given ---
 
@@ -87,8 +88,6 @@ def load_test_connection_file_with_default(context):
 def load_default_connection_file(context):
     """Set up the context manager for a given connection_type."""
     try:
-        # context.connection_type = "sqlite"
-        # context.connection_name = "my-sqlite-database"
         context.manager = ConnectionManager()
         context.exc = None
     except Exception as e:
@@ -228,6 +227,7 @@ def load_test_connection_file_with_wrong_defaults(context):
     except Exception as e:
         context.exc = e
 
+
 # --- When ---
 
 
@@ -244,15 +244,8 @@ def entry_exists(context, con_type):
         sql=sql
     )
 
-    correct_rst = (
-        # data
-        [(1, "foo"), (2, "1")],
-
-        # headings
-        ["id", "testfield"]
-    )
-
-    assert rst == correct_rst
+    assert rst.data == [(1, "foo"), (2, "1")]
+    assert rst.headings == ["id", "testfield"]
 
 
 @then("the entry exists in the internal table on {con_type}")
@@ -266,15 +259,8 @@ def internal_entry_exists(context, con_type):
         sql=sql
     )
 
-    correct_rst = (
-        # data
-        [(1, "foo"), (2, "1")],
-
-        # headings
-        ["id", "testfield"]
-    )
-
-    assert rst == correct_rst
+    assert rst.data == [(1, "foo"), (2, "1")]
+    assert rst.headings == ["id", "testfield"]
 
 
 @then('it throws a {type} with message "{msg}"')
@@ -357,22 +343,14 @@ def entry_exists_in_default_table(context):
         ["id", "testfield"]
     )
 
-    print(rst)
-    print(correct_rst)
-    assert rst == correct_rst
+    assert rst.data == [(1, "foo"), (2, "1")]
+    assert rst.headings == ["id", "testfield"]
 
     # check with the known default connection
     rst = context.manager.recordset(con_name="my-default-sqlite-database",
                                     sql=sql)
 
-    correct_rst = (
-        # data
-        [(1, "foo"), (2, "1")],
-
-        # headings
-        ["id", "testfield"]
-    )
-
-    assert rst == correct_rst
+    assert rst.data == [(1, "foo"), (2, "1")]
+    assert rst.headings == ["id", "testfield"]
 
 # --- Then ---

--- a/features/steps/general.py
+++ b/features/steps/general.py
@@ -7,7 +7,7 @@ from simqle import (
 )
 from simqle import internal
 from simqle.exceptions import *
-from constants import (
+from .constants import (
     CONNECTIONS_FILE,
     CREATE_TABLE_SYNTAX,
     TEST_TABLE_NAME,

--- a/features/steps/return_types.py
+++ b/features/steps/return_types.py
@@ -1,0 +1,172 @@
+"""Steps testing the multiple possible return types."""
+
+from behave import given, when, then
+
+from features.steps.constants import TEST_TABLE_NAME
+from simqle.recordset import RecordSet, RecordScalar, Record
+from simqle.recordset.exceptions import UnknownHeadingError, NoScalarDataError
+
+
+@then("we can return a Recordset")
+def recordset_method(context):
+    """Test the various Recordset methods"""
+    sql = "SELECT id, testfield FROM {}".format(TEST_TABLE_NAME)
+    rst = context.manager.recordset(con_name="my-sqlite-database", sql=sql)
+
+    correct_data = [(1, "foo"), (2, "1")]
+    correct_dicts = [
+        {"id": 1, "testfield": "foo"},
+        {"id": 2, "testfield": "1"},
+    ]
+
+    assert isinstance(rst, RecordSet)
+
+    assert rst.headings == ["id", "testfield"]
+    assert rst.data == correct_data
+
+    # data exists means this is true
+    assert bool(rst)
+
+    # standard iteration
+    for row, test_row in zip(rst, correct_data):
+        assert row == test_row
+
+    # iterate over dicts
+    for rst_dict, test_dict in zip(rst.dict_gen(), correct_dicts):
+        assert rst_dict == test_dict
+
+    # convert the whole rst into a list of dicts
+    for rst_dict, test_dict in zip(rst.as_dict(), correct_dicts):
+        assert rst_dict == test_dict
+
+    # iterate over one column
+    for value, test_value in zip(rst.column("testfield"), ["foo", "1"]):
+        assert value == test_value
+
+    # column with wrong column name raises the correct error
+    try:
+        _ = rst.column("Not a Column")
+        raise
+    except UnknownHeadingError:
+        pass
+
+
+@then("we can return a Record")
+def record_method(context):
+    """Test the various Records methods"""
+    sql = "SELECT id, testfield FROM {}".format(TEST_TABLE_NAME)
+    record = context.manager.record(con_name="my-sqlite-database", sql=sql)
+
+    assert isinstance(record, Record)
+
+    assert record.headings == ["id", "testfield"]
+
+    # Record.data is just a tuple
+    correct_data = (1, "foo")
+    assert record.data == correct_data
+
+    # Record.as_dict is a dict, not a list of dicts like RecordSet
+    assert record.as_dict == {"id": 1, "testfield": "foo"}
+
+    # the record exists, so returning True
+    assert bool(record)
+
+    assert record["id"] == 1
+    assert record["testfield"] == "foo"
+
+    try:
+        _ = record["wrong field"]
+        raise
+    except UnknownHeadingError:
+        pass
+
+
+@then("we can return a RecordScalar")
+def record_scalar_method(context):
+    sql = "SELECT testfield FROM {}".format(TEST_TABLE_NAME)
+    scalar = context.manager.record_scalar(con_name="my-sqlite-database",
+                                           sql=sql)
+
+    assert isinstance(scalar, RecordScalar)
+    assert bool(scalar)
+
+    assert scalar.datum == "foo"
+
+
+@then("we can return an empty Recordset")
+def empty_recordset_method(context):
+    """Test the various Recordset methods"""
+    sql = "SELECT id, testfield FROM {}".format(TEST_TABLE_NAME)
+    rst = context.manager.recordset(con_name="my-sqlite-database", sql=sql)
+
+    assert isinstance(rst, RecordSet)
+
+    assert rst.headings == ["id", "testfield"]
+    assert rst.data is None
+
+    # data doesn't exist meaning this is False
+    assert not bool(rst)
+
+    # standard iteration
+    for _ in rst:
+        raise
+
+    # iterate over dicts
+    for _ in rst.dict_gen():
+        raise
+
+    # convert the whole rst into a list of dicts
+    for _ in rst.as_dict():
+        raise
+
+    # iterate over one column
+    for _ in rst.column("testfield"):
+        raise
+
+    # column with wrong column name raises the correct error
+    try:
+        _ = rst.column("Not a Column")
+        raise
+    except UnknownHeadingError:
+        pass
+
+
+@then("we can return an empty Record")
+def empty_record_method(context):
+    """Test the various Records methods"""
+    sql = "SELECT id, testfield FROM {}".format(TEST_TABLE_NAME)
+    record = context.manager.record(con_name="my-sqlite-database", sql=sql)
+
+    assert isinstance(record, Record)
+
+    assert record.headings == ["id", "testfield"]
+
+    # Record.data is just a tuple
+    assert record.data is None
+
+    # Record.as_dict is a dict, not a list of dicts like RecordSet
+    assert record.as_dict == {}
+
+    # the record doesn't exist, so returning False
+    assert not bool(record)
+
+    try:
+        _ = record["testfield"]
+        raise
+    except UnknownHeadingError:
+        pass
+
+
+@then("we can return an empty RecordScalar")
+def empty_record_scalar_method(context):
+    sql = "SELECT testfield FROM {}".format(TEST_TABLE_NAME)
+    scalar = context.manager.record_scalar(con_name="my-sqlite-database",
+                                           sql=sql)
+
+    assert isinstance(scalar, RecordScalar)
+    assert not bool(scalar)
+
+    try:
+        assert scalar.datum == "foo"
+    except NoScalarDataError:
+        pass

--- a/features/undefined-connection.feature
+++ b/features/undefined-connection.feature
@@ -9,8 +9,8 @@ Feature: Connecting to Default Files
 	Scenario: load a connections file from a default location
 		Given we have a .connections.yaml file in root
 		When we load a connection file from a default location
-		AND we create a table on sqlite
-		AND we insert an entry on sqlite
+		And we create a table on sqlite
+		And we insert an entry on sqlite
 		Then the entry exists in the table on sqlite
 
 	@fixture.sqlite

--- a/features/undefined-connection.feature
+++ b/features/undefined-connection.feature
@@ -1,20 +1,20 @@
 Feature: Connecting to Default Files
 
-	As a SimQLe user
-	I want to be able to load a .connections.yaml file from a default location
-	so I don't have to specify it in a load_connections method
+  As a SimQLe user
+  I want to be able to load a .connections.yaml file from a default location
+  so I don't have to specify it in a load_connections method
 
-	@fixture.connections.file
-	@fixture.sqlite
-	Scenario: load a connections file from a default location
-		Given we have a .connections.yaml file in root
-		When we load a connection file from a default location
-		And we create a table on sqlite
-		And we insert an entry on sqlite
-		Then the entry exists in the table on sqlite
+  @fixture.connections.file
+  @fixture.sqlite
+  Scenario: load a connections file from a default location
+    Given we have a .connections.yaml file in root
+    When we load a connection file from a default location
+    And we create a table on sqlite
+    And we insert an entry on sqlite
+    Then the entry exists in the table on sqlite
 
-	@fixture.sqlite
-	Scenario: An error occurs when no default files are found
-		Given we don't have a .connections.yaml files in default locations
-		When we load a connection file from a default location
-		Then it throws a NoConnectionsFileError with message "No file_name is specified and no files in default locations are found."
+  @fixture.sqlite
+  Scenario: An error occurs when no default files are found
+    Given we don't have a .connections.yaml files in default locations
+    When we load a connection file from a default location
+    Then it throws a NoConnectionsFileError with message "No file_name is specified and no files in default locations are found."

--- a/poetry.lock
+++ b/poetry.lock
@@ -89,6 +89,14 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 version = "0.9.0"
 
 [[package]]
+category = "main"
+description = "psycopg2 - Python-PostgreSQL Database Adapter"
+name = "psycopg2"
+optional = false
+python-versions = ">=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*"
+version = "2.8.3"
+
+[[package]]
 category = "dev"
 description = "library with cross-python path, ini-parsing, io, code, log facilities"
 name = "py"
@@ -189,7 +197,7 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 version = "1.3.2"
 
 [metadata]
-content-hash = "679af36282b7e104b36c58a9c0b1ad490270b589596a4dd8d37883a43ba4413f"
+content-hash = "04aea72de3877fb93a7367d0b4c94486e3dc600544111adc6533e044c4370f71"
 python-versions = "^3.6"
 
 [metadata.hashes]
@@ -203,6 +211,7 @@ more-itertools = ["2112d2ca570bb7c3e53ea1a35cd5df42bb0fd10c45f0fb97178679c3c03d6
 parse = ["1b68657434d371e5156048ca4a0c5aea5afc6ca59a2fea4dd1a575354f617142"]
 parse-type = ["6e906a66f340252e4c324914a60d417d33a4bea01292ea9bbf68b4fc123be8c9", "f596bdc75d3dd93036fbfe3d04127da9f6df0c26c36e01e76da85adef4336b3c"]
 pluggy = ["19ecf9ce9db2fce065a7a0586e07cfb4ac8614fe96edf628a264b1c70116cf8f", "84d306a647cc805219916e62aab89caa97a33a1dd8c342e87a37f91073cd4746"]
+psycopg2 = ["128d0fa910ada0157bba1cb74a9c5f92bb8a1dca77cf91a31eb274d1f889e001", "227fd46cf9b7255f07687e5bde454d7d67ae39ca77e170097cdef8ebfc30c323", "2315e7f104681d498ccf6fd70b0dba5bce65d60ac92171492bfe228e21dcc242", "4b5417dcd2999db0f5a891d54717cfaee33acc64f4772c4bc574d4ff95ed9d80", "640113ddc943522aaf71294e3f2d24013b0edd659b7820621492c9ebd3a2fb0b", "897a6e838319b4bf648a574afb6cabcb17d0488f8c7195100d48d872419f4457", "8dceca81409898c870e011c71179454962dec152a1a6b86a347f4be74b16d864", "b1b8e41da09a0c3ef0b3d4bb72da0dde2abebe583c1e8462973233fd5ad0235f", "cb407fccc12fc29dc331f2b934913405fa49b9b75af4f3a72d0f50f57ad2ca23", "d3a27550a8185e53b244ad7e79e307594b92fede8617d80200a8cce1fba2c60f", "f0e6b697a975d9d3ccd04135316c947dd82d841067c7800ccf622a8717e98df1"]
 py = ["64f65755aee5b381cea27766a3a147c3f15b9b6b9ac88676de66ba2ae36793fa", "dc639b046a6e2cff5bbe40194ad65936d6ba360b52b3c3fe1d08a82dd50b5e53"]
 pycodestyle = ["95a2219d12372f05704562a14ec30bc76b05a5b297b21a5dfe3f6fac3491ae56", "e40a936c9a450ad81df37f549d676d127b1b66000a6c500caa2b085bc0ca976c"]
 pydocstyle = ["2258f9b0df68b97bf3a6c29003edc5238ff8879f1efb6f1999988d934e432bd8", "5741c85e408f9e0ddf873611085e819b809fca90b619f5fd7f34bd4959da3dd4", "ed79d4ec5e92655eccc21eb0c6cf512e69512b4a97d215ace46d17e4990f2039"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -29,4 +29,3 @@ tqdm==4.31.1
 twine==1.13.0
 urllib3==1.24.2
 webencodings==0.5.1
-psycopg2==2.8.2

--- a/simqle/__init__.py
+++ b/simqle/__init__.py
@@ -1,6 +1,6 @@
 """Import commonly used functions."""
 
-__version__ = '0.4.2'
+__version__ = '0.5.0'
 
 
 from simqle.internal import (

--- a/simqle/connection_manager.py
+++ b/simqle/connection_manager.py
@@ -12,6 +12,7 @@ from simqle.exceptions import (
     MultipleDefaultConnectionsError, EnvironSyncError, UnknownSimqleMode,
     NoDefaultConnectionError,
 )
+from simqle.recordset import RecordSet, RecordScalar, Record
 
 
 class ConnectionManager:
@@ -76,11 +77,17 @@ class ConnectionManager:
 
     # --- Public Methods: ---
 
-    def recordset(self, sql, con_name=None, params=None):
-        """Return recordset from connection."""
-        con_name = self._con_name(con_name)
-        connection = self._get_connection(con_name)
-        return connection.recordset(sql, params=params)
+    def recordset(self, sql, con_name, params=None):
+        headings, data = self._recordset(sql, con_name, params=params)
+        return RecordSet(headings=headings, data=data)
+
+    def record_scalar(self, sql, con_name, params=None):
+        headings, data = self._recordset(sql, con_name, params=params)
+        return RecordScalar(headings=headings, data=data)
+
+    def record(self, sql, con_name, params=None):
+        headings, data = self._recordset(sql, con_name, params=params)
+        return Record(headings=headings, data=data)
 
     def execute_sql(self, sql, con_name=None, params=None):
         """Execute SQL on a given connection."""
@@ -108,6 +115,13 @@ class ConnectionManager:
         self._default_connection_name = None
 
     # --- Private Methods: ---
+
+    def _recordset(self, sql, con_name=None, params=None):
+        """Return headings and data from a connection."""
+        con_name = self._con_name(con_name)
+        connection = self._get_connection(con_name)
+        return connection.recordset(sql, params=params)
+
 
     def _load_yaml_file(self, connections_file):
         """Load the configuration from the given file."""
@@ -262,6 +276,7 @@ class _Connection:
         connection.close()
 
         return data, headings
+        # return RecordSet(headings=headings, data=data)
 
     @staticmethod
     def _bind_sql(sql, params):

--- a/simqle/connection_manager.py
+++ b/simqle/connection_manager.py
@@ -77,15 +77,15 @@ class ConnectionManager:
 
     # --- Public Methods: ---
 
-    def recordset(self, sql, con_name, params=None):
+    def recordset(self, sql, con_name=None, params=None):
         headings, data = self._recordset(sql, con_name, params=params)
         return RecordSet(headings=headings, data=data)
 
-    def record_scalar(self, sql, con_name, params=None):
+    def record_scalar(self, sql, con_name=None, params=None):
         headings, data = self._recordset(sql, con_name, params=params)
         return RecordScalar(headings=headings, data=data)
 
-    def record(self, sql, con_name, params=None):
+    def record(self, sql, con_name=None, params=None):
         headings, data = self._recordset(sql, con_name, params=params)
         return Record(headings=headings, data=data)
 
@@ -121,7 +121,6 @@ class ConnectionManager:
         con_name = self._con_name(con_name)
         connection = self._get_connection(con_name)
         return connection.recordset(sql, params=params)
-
 
     def _load_yaml_file(self, connections_file):
         """Load the configuration from the given file."""
@@ -275,7 +274,7 @@ class _Connection:
         transaction.commit()
         connection.close()
 
-        return data, headings
+        return headings, data
         # return RecordSet(headings=headings, data=data)
 
     @staticmethod

--- a/simqle/recordset/__init__.py
+++ b/simqle/recordset/__init__.py
@@ -1,0 +1,1 @@
+from .recordset import RecordSet, RecordScalar, Record

--- a/simqle/recordset/exceptions.py
+++ b/simqle/recordset/exceptions.py
@@ -1,0 +1,29 @@
+"""Define exceptions for the RecordSet Object."""
+
+
+class UnknownHeadingError(Exception):
+    def __init__(self, heading):
+        msg = "Unknown heading: [{}]".format(heading)
+        super().__init__(msg)
+        self.message = msg
+
+
+class InconsistentRecordSetError(Exception):
+    def __init__(self, msg):
+        msg = "RecordSet cannot be intialised: {}".format(msg)
+        super().__init__(msg)
+        self.message = msg
+
+
+class NotAScalarError(Exception):
+    def __init__(self, msg):
+        msg = "RecordSet cannot be intialised: {}".format(msg)
+        super().__init__(msg)
+        self.message = msg
+
+
+class NoScalarDataError(Exception):
+    def __init__(self):
+        msg = "No datum was returned"
+        super().__init__(msg)
+        self.message = msg

--- a/simqle/recordset/exceptions.py
+++ b/simqle/recordset/exceptions.py
@@ -8,20 +8,6 @@ class UnknownHeadingError(Exception):
         self.message = msg
 
 
-class InconsistentRecordSetError(Exception):
-    def __init__(self, msg):
-        msg = "RecordSet cannot be intialised: {}".format(msg)
-        super().__init__(msg)
-        self.message = msg
-
-
-class NotAScalarError(Exception):
-    def __init__(self, msg):
-        msg = "RecordSet cannot be intialised: {}".format(msg)
-        super().__init__(msg)
-        self.message = msg
-
-
 class NoScalarDataError(Exception):
     def __init__(self):
         msg = "No datum was returned"

--- a/simqle/recordset/recordset.py
+++ b/simqle/recordset/recordset.py
@@ -1,0 +1,115 @@
+"""Define the RecordSet Class."""
+from .exceptions import UnknownHeadingError, NoScalarDataError
+
+
+class RecordSet:
+    """
+    The RecordSet Object.
+
+    This is the object returned by the ConnectionManager from the recordset
+    method. Saves the output of the SQL query once, but allows several ways
+    to access it.
+
+    This object is initialised using the normal __init__ method, as there
+    isn't much use for an instance of a totally empty recordset. If we need it
+    in the future, we can move the __init__ method to a class method.
+    """
+
+    def __init__(self, headings, data):
+        """
+        Initialise this object with data and headings.
+
+        <data> can be None, representing no rows of data for the given
+        headings.
+        """
+        self.data = data or None
+        self.headings = headings
+
+    def __bool__(self):
+        return self.data is None
+
+    def __iter__(self):
+        if self:
+            return iter(self.data)
+
+    def dict_gen(self):
+        """Iterate over records as dictionaries."""
+        for record in self.data:
+            yield {h: v for h, v in zip(self.headings, record)}
+
+    def as_dict(self):
+        """
+        Return the records as a list of dicts.
+
+        Creates a copy of the data, so isn't very efficient for larger
+        data sets.
+        """
+        return [{h: v for h, v in zip(self.headings, record)}
+                for record in self.data]
+
+    def column(self, heading):
+        """Return a list of data for a particular heading."""
+        try:
+            heading_index = self.headings.index(heading)
+        except ValueError as e:
+            raise UnknownHeadingError(heading) from e
+
+        return [record[heading_index] for record in self.data]
+
+
+class RecordScalar:
+    """
+    The RecordScalar object assumes that a single value is being returned.
+
+    For example, you would use this when you are trying to find 1 data point
+    for a single identity. The same data passed to a RecordSet object is
+    passed to this class, however if multiple columns or rows are passed,
+    only the top left value is kept.
+
+    Note, we have to distinguish between a NULL value returned, and no rows
+    returned. __bool__ is therefore "was a record returned" by the query, and
+    then you use self.datum truthiness as per normal.
+    """
+
+    def __init__(self, headings, data):
+        # Only keep the first heading
+        self.heading = headings[0]
+
+        # Only keep None or the first value of data.
+        if data:
+            self._datum = [data[0][0]]
+        else:
+            self._datum = None
+
+    def __bool__(self):
+        # was a record returned
+        return bool(self._datum)
+
+    @property
+    def datum(self):
+        if not self:
+            raise NoScalarDataError()
+        return self._datum[0]
+
+
+class Record:
+    """
+    The Record object assumes only a single record is being returned.
+
+    If multiple rows are returned, only the first is kept.
+    """
+
+    def __init__(self, headings, data):
+        self.data = data[0]
+        self.headings = headings
+        self._dict = {k: v for k, v in zip(headings, data)}
+
+    def __getattr__(self, heading):
+        try:
+            return self._dict[heading]
+        except KeyError as e:
+            raise UnknownHeadingError(heading) from e
+
+    @property
+    def as_dict(self):
+        return self._dict


### PR DESCRIPTION
Adding the classes RecordSet, RecordScalar and Record as the return types for ConnectionManager.record[set/scalar/].

Each assumes a different result type, and modifies data to match that type. For example, RecordScalar assumes only a datum is being received, and Record assumes just one record. Convenience functions around all 3 have been added.

The tests haven't been updated.