### PR TITLE
add the sdatum method to RecordScalar

### DIFF
--- a/docs/references.md
+++ b/docs/references.md
@@ -175,4 +175,6 @@ Extra rows and columns are discarded.
 
 >>> bool(result)  # the truthiness of the datapoint
 True
+
+>>> result.sdatum("bar")  # a safe datum that returns "bar" if the record doesn't exist
 ```

--- a/features/steps/return_types.py
+++ b/features/steps/return_types.py
@@ -92,6 +92,8 @@ def record_scalar_method(context):
 
     assert scalar.datum == "foo"
 
+    assert scalar.sdatum("bar") == "foo"
+
 
 @then("we can return an empty Recordset")
 def empty_recordset_method(context):
@@ -170,3 +172,7 @@ def empty_record_scalar_method(context):
         assert scalar.datum == "foo"
     except NoScalarDataError:
         pass
+
+    assert scalar.sdatum("bar") == "bar"
+    assert scalar.sdatum() is None
+

--- a/simqle/recordset/recordset.py
+++ b/simqle/recordset/recordset.py
@@ -48,8 +48,10 @@ class RecordSet:
         data sets.
         """
         if self:
-            return [{h: v for h, v in zip(self.headings, record)}
-                    for record in self.data or []]
+            return [
+                {h: v for h, v in zip(self.headings, record)}
+                for record in self.data or []
+            ]
         return []
 
     def column(self, heading):
@@ -94,6 +96,17 @@ class RecordScalar:
     def datum(self):
         if not self:
             raise NoScalarDataError()
+        return self._datum[0]
+
+    def sdatum(self, default=None):
+        """
+        Return the datum with a default value if the record doesn't exist.
+
+        sdatum stands for Safe Datum, providing a default value instead of 
+        raising an error if the record doesn't exist.
+        """
+        if not self:
+            return default
         return self._datum[0]
 
 


### PR DESCRIPTION
the sdatum method stands for Safe Datum, and has a default value
option that is returned only if the record doesn't exist.

for example, given result.sdatum(1) would return:

data = 2, then 2
data = 0, then 0
data = None, then None
data doesn't exist, then 1

Which is different to the .datum property, which if the data doesn't
exist, then throws an error.